### PR TITLE
NTI-4672: Our code is not in errorcode but in simple code property

### DIFF
--- a/src/errors/field/Factory.js
+++ b/src/errors/field/Factory.js
@@ -3,7 +3,8 @@ import EventEmitter from 'events';
 const DATA = Symbol('Data');
 
 function getMessageForReason (reason, overrides) {
-	const {ErrorCode: code} = reason || {};
+	const {ErrorCode, code: reasonCode} = reason || {};
+	const code = ErrorCode || reasonCode;
 	const override = overrides[code];
 
 	if (typeof override === 'function') {


### PR DESCRIPTION
forgot to open a pull request on this. It relates to errors for empty code blocks