### PR TITLE
NTI-6810: Getting cut off

### DIFF
--- a/src/components/inputs/select/View.jsx
+++ b/src/components/inputs/select/View.jsx
@@ -346,6 +346,7 @@ export default class SelectInput extends React.Component {
 				role="listbox"
 			>
 				<Triggered
+					constrain
 					trigger={this.renderLabel()}
 					verticalAlign={Triggered.ALIGNMENTS.BOTTOM}
 					horizontalAlign={Triggered.ALIGNMENTS.LEFT_OR_RIGHT}

--- a/src/components/inputs/select/View.scss
+++ b/src/components/inputs/select/View.scss
@@ -37,6 +37,7 @@
 			}
 		}
 
+
 		&.searchable.focused {
 			.selected-option {
 				display: none;
@@ -101,15 +102,9 @@ ul.nti-select-input-options {
 	margin: 0;
 	padding: 0;
 	list-style: none;
-	position: absolute;
-	width: 100%;
-	top: calc(100% - 1px);
-	left: 0;
 	background: white;
 	box-shadow: 1px 2px 2px 0 rgba(0, 0, 0, 0.1);
 	border: 1px solid $border-grey-light;
-	z-index: 99;
-	backface-visibility: hidden;
 
 	li {
 		border-bottom: 1px solid $border-grey-light;


### PR DESCRIPTION
We removed the absolute positioning because we are now render in a flyout. This was a hold over when we rendered ourselves. 